### PR TITLE
fix: use before operator linebreak

### DIFF
--- a/lint.json
+++ b/lint.json
@@ -12,14 +12,19 @@
     "strict": "warn",
     "comma-dangle": ["error", "never"],
     "object-curly-spacing": ["error", "always"],
-    "quotes": ["error", "single", {"avoidEscape": true, "allowTemplateLiterals": true}],
+    "quotes": [
+      "error",
+      "single",
+      { "avoidEscape": true, "allowTemplateLiterals": true }
+    ],
     "consistent-this": ["error", "self"],
     "max-len": ["error", 120],
-    "camelcase": ["error", {"properties": "never"}],
+    "camelcase": ["error", { "properties": "never" }],
     "no-unused-expressions": "off",
     "one-var": ["error", "never"],
-    "indent": ["error", 2, {"SwitchCase": 1, "MemberExpression": 1}],
+    "indent": ["error", 2, { "SwitchCase": 1, "MemberExpression": 1 }],
     "no-multi-spaces": ["error"],
-    "linebreak-style": [ "error", "unix" ]
-    }
+    "linebreak-style": ["error", "unix"],
+    "operator-linebreak": [2, "before"]
+  }
 }


### PR DESCRIPTION
Use the before operator linebreak, to 
* meet the prettier config.
* make the code more readable