### PR TITLE
added mocha-no-only plugin to the eslint config

### DIFF
--- a/lint.json
+++ b/lint.json
@@ -29,6 +29,6 @@
     "no-multi-spaces": ["error"],
     "linebreak-style": ["error", "unix"],
     "operator-linebreak": [2, "before"],
-    "mocha-no-only/mocha-no-only": ["error"]
+    "mocha-no-only/mocha-no-only": ["warn"]
   }
 }

--- a/lint.json
+++ b/lint.json
@@ -8,6 +8,9 @@
   "parserOptions": {
     "ecmaVersion": 8
   },
+  "plugins": [
+    "mocha-no-only"
+  ],
   "rules": {
     "strict": "warn",
     "comma-dangle": ["error", "never"],
@@ -25,6 +28,7 @@
     "indent": ["error", 2, { "SwitchCase": 1, "MemberExpression": 1 }],
     "no-multi-spaces": ["error"],
     "linebreak-style": ["error", "unix"],
-    "operator-linebreak": [2, "before"]
+    "operator-linebreak": [2, "before"],
+    "mocha-no-only/mocha-no-only": ["error"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "url": "https://github.com/Wiredcraft/eslint-config-wcl-backend"
   },
   "dependencies": {
-    "eslint-config-loopback": "^8.0.0"
+    "eslint-config-loopback": "^8.0.0",
+    "eslint-plugin-mocha-no-only": "0.0.6"
   }
 }


### PR DESCRIPTION
i think we should add the [eslint-plugin-mocha-no-only](https://www.npmjs.com/package/eslint-plugin-mocha-no-only) plugin to our eslint config to warn if there is `.only` at the test code